### PR TITLE
Remove unnecessary config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,7 @@
 	<PropertyGroup>
 		<Version>2.0.7</Version>	
 		<Nullable>enable</Nullable>
-		<TargetFramework>net6.0</TargetFramework>	
-		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+		<TargetFramework>net6.0</TargetFramework>
 		<IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled> 		
 		<Description>github加速神器</Description>
 		<Copyright>https://github.com/dotnetcore/FastGithub</Copyright>


### PR DESCRIPTION
This `DisableImplicitNamespaceImports` is only needed for .NET 6 preview 7, no need for .NET 6 stable release