### PR TITLE
改进FastGithub对SSL证书验证失败的操作

### DIFF
--- a/FastGithub.HttpServer/Certs/CertService.cs
+++ b/FastGithub.HttpServer/Certs/CertService.cs
@@ -94,7 +94,7 @@ namespace FastGithub.HttpServer.Certs
                 this.logger.LogWarning($"请根据你的系统平台手动安装和信任CA证书{this.CaCerFilePath}");
             }
 
-            GitConfigSslverify(false);
+            GitConfigSSLChannel("schannel");
         }
 
         /// <summary>
@@ -102,14 +102,14 @@ namespace FastGithub.HttpServer.Certs
         /// </summary>
         /// <param name="value">是否验证</param>
         /// <returns></returns>
-        public static bool GitConfigSslverify(bool value)
+        public static bool GitConfigSSLChannel(string value)
         {
             try
             {
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = "git",
-                    Arguments = $"config --global http.sslverify {value.ToString().ToLower()}",
+                    Arguments = $"config --global http.sslbackend {value.ToLower()}",
                     UseShellExecute = true,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden

--- a/FastGithub.UI/Resource/issue.html
+++ b/FastGithub.UI/Resource/issue.html
@@ -69,7 +69,7 @@
         </p>
         <p>
             <span class="badge">2</span>
-            <span>在cmd输入：</span><code>git config --global http.sslverify false</code>
+            <span>在cmd输入：</span><code>git config --global http.sslbackend schannel</code>
         </p>
     </div>
 

--- a/README.html
+++ b/README.html
@@ -417,7 +417,7 @@ code {
 <h3 id="4-%E8%AF%81%E4%B9%A6%E9%AA%8C%E8%AF%81">4 证书验证</h3>
 <h4 id="41-git">4.1 git</h4>
 <p>git操作提示<code>SSL certificate problem</code></br>
-需要关闭git的证书验证：<code>git config --global http.sslverify false</code></p>
+让Git使用系统的证书库：<code>git config --global http.sslbackend schannel</code></p>
 <h4 id="42-firefox">4.2 firefox</h4>
 <p>firefox提示<code>连接有潜在的安全问题</code></br>
 设置-&gt;隐私与安全-&gt;证书-&gt;查看证书-&gt;证书颁发机构，导入cacert/fastgithub.cer，勾选“信任由此证书颁发机构来标识网站”</p>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ github加速神器，解决github打不开、用户头像无法加载、releases
 ### 4 证书验证
 #### 4.1 git
 git操作提示`SSL certificate problem`</br>
-需要关闭git的证书验证：`git config --global http.sslverify false`
+让Git使用系统的证书库：`git config --global http.sslbackend schannel`
 
 #### 4.2 firefox
 firefox提示`连接有潜在的安全问题`</br>


### PR DESCRIPTION
如果我们禁用Git的SSL验证，依然会警告你禁用了SSL验证。
但是，如果我们将Git验证证书的渠道从OpenSSL改到系统自带的证书库（也就是我们保存证书的地方），而不是禁用SSL就可以完美解决这个问题。
并且，禁用SSL也使得用户在进行`clone` `push` `pull` `fetch` 等需要进行网络收发的命令时安全性大大降低。

脚注：以上使用SSL统称TLS/SSL